### PR TITLE
Normalize path prefix before sending to clients

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,7 +16,7 @@ module.exports = (staticPath, globs, webPrefix) => {
         console.log(`${prefix} update detected ${file}`)
         for (const client of clients) {
           client.write(`event: ${path.extname(file)}\n`)
-          client.write(`data: ${webPrefix}/${path.relative(staticPath, file)}\n\n`)
+          client.write(`data: ${path.normalize(webPrefix + '/')}${path.relative(staticPath, file)}\n\n`)
         }
       })
     })


### PR DESCRIPTION
This small change allows my configuration to work:

```
hot-rld -s compiled *.css -w /
```

My CSS is written to `/compiled/index.css`, but it's accessed at `/index.css`. Prior to this change `hot-rld` would not be able to find the corresponding `<link>` because it was looking for `//index.css` instead of `/index.css`. This should also resolve any other issues that might come up with the prefix (such as someone using `./` in either the static or web prefix fields).
