### PR TITLE
Eliminate FOUC on CSS updates

### DIFF
--- a/client.js
+++ b/client.js
@@ -19,7 +19,10 @@ module.exports = `;(function () {
       link.href = event.data + '?cachebust=' + Date.now()
       var prevNode = document.querySelector('link[href^="' + event.data + '"]')
       if (!prevNode) return console.log('[hot-rld] cannot find <link> tag to replace')
-      prevNode.parentNode.replaceChild(link, prevNode)
+      prevNode.parentNode.insertBefore(link, prevNode.nextSibling)
+      function removePrevNode () { if (prevNode.parentNode) prevNode.parentNode.removeChild(prevNode) }
+      link.onload = removePrevNode
+      setTimeout(removePrevNode, 500)
     }, 100)
   })
 })();`


### PR DESCRIPTION
When using `replaceChild` to switch stylesheets there's a brief moment of unstyled content. By waiting for `link.onload`, the new styles are in place before the old styles are removed, eliminating the FOUC.

The `setTimeout` exists just in case the browser does not support the `onload` event on `link` elements.