### PR TITLE
Require JS without turning it into a string

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,4 +1,4 @@
-module.exports = `;(function () {
+;(function () {
   var es = new window.EventSource('//localhost:9909')
   es.addEventListener('.js', function (event) {
     setTimeout(function () {
@@ -25,4 +25,4 @@ module.exports = `;(function () {
       setTimeout(removePrevNode, 500)
     }, 100)
   })
-})();`
+})();


### PR DESCRIPTION
I'm not sure why you had `client.js` wrapped in a template string, but I'm currently using this branch where I just require it straight up like so:

```js
if (process.env.NODE_ENV === 'development') {
  require('hot-rld/client');
}
```