### PR TITLE
Improvements to client setup

### DIFF
--- a/_client.js
+++ b/_client.js
@@ -1,0 +1,23 @@
+var port = window.__HOT_RLD_PORT__ || 9909
+var es = new window.EventSource('//localhost:' + port)
+es.addEventListener('.js', function (event) {
+  console.log('[hot-rld] ' + event.data + ' updated')
+  var script = document.createElement('script')
+  script.type = 'text/javascript'
+  script.src = event.data + '?cachebust=' + Date.now()
+  var prevNode = document.querySelector('script[src^="' + event.data + '"]')
+  if (!prevNode) return console.log('[hot-rld] cannot find <script> tag to replace')
+  prevNode.parentNode.replaceChild(script, prevNode)
+})
+es.addEventListener('.css', function (event) {
+  console.log('[hot-rld] ' + event.data + ' updated')
+  var link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = event.data + '?cachebust=' + Date.now()
+  var prevNode = document.querySelector('link[href^="' + event.data + '"]')
+  if (!prevNode) return console.log('[hot-rld] cannot find <link> tag to replace')
+  prevNode.parentNode.insertBefore(link, prevNode.nextSibling)
+  function removePrevNode () { if (prevNode.parentNode) prevNode.parentNode.removeChild(prevNode) }
+  link.onload = removePrevNode
+  setTimeout(removePrevNode, 500)
+})

--- a/client.js
+++ b/client.js
@@ -1,28 +1,3 @@
 module.exports = `;(function () {
-  var es = new window.EventSource('//localhost:9909')
-  es.addEventListener('.js', function (event) {
-    setTimeout(function () {
-      console.log('[hot-rld] ' + event.data + ' updated')
-      var script = document.createElement('script')
-      script.type = 'text/javascript'
-      script.src = event.data + '?cachebust=' + Date.now()
-      var prevNode = document.querySelector('script[src^="' + event.data + '"]')
-      if (!prevNode) return console.log('[hot-rld] cannot find <script> tag to replace')
-      prevNode.parentNode.replaceChild(script, prevNode)
-    }, 100)
-  })
-  es.addEventListener('.css', function (event) {
-    setTimeout(function () {
-      console.log('[hot-rld] ' + event.data + ' updated')
-      var link = document.createElement('link')
-      link.rel = 'stylesheet'
-      link.href = event.data + '?cachebust=' + Date.now()
-      var prevNode = document.querySelector('link[href^="' + event.data + '"]')
-      if (!prevNode) return console.log('[hot-rld] cannot find <link> tag to replace')
-      prevNode.parentNode.insertBefore(link, prevNode.nextSibling)
-      function removePrevNode () { if (prevNode.parentNode) prevNode.parentNode.removeChild(prevNode) }
-      link.onload = removePrevNode
-      setTimeout(removePrevNode, 500)
-    }, 100)
-  })
+  ${require('fs').readFileSync(`${__dirname}/_client.js`)}
 })();`

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
   },
   "homepage": "https://github.com/bengourley/hot-rld#readme",
   "browser": {
-    "hot-rld/client.js": "./_client.js"
+    "./client.js": "./_client.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Hot reload some browser javascript and css",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "test": "standard . && tape test/*.test.js"
+  },
   "bin": {
     "hot-rld": "cli.js"
   },
@@ -13,7 +16,8 @@
     "minimist": "^1.2.0"
   },
   "devDependencies": {
-    "standard": "^8.5.0"
+    "standard": "^8.5.0",
+    "tape": "^4.6.3"
   },
   "author": "Ben Gourley",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/bengourley/hot-rld/issues"
   },
-  "homepage": "https://github.com/bengourley/hot-rld#readme"
+  "homepage": "https://github.com/bengourley/hot-rld#readme",
+  "browser": {
+    "hot-rld/client.js": "./_client.js"
+  }
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,3 @@
+const test = require('tape')
+
+test('cli') // needs tests

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+const client = require('../client')
+
+test('client', t => {
+  t.plan(2)
+  let events = []
+  const EventSource = function (url) {
+    t.equal(url, '//localhost:9909', 'url should default to localhost:9909')
+  }
+  EventSource.prototype.addEventListener = function (event) {
+    events.push(event)
+  }
+  window = { EventSource } // eslint-disable-line
+  eval(client) // eslint-disable-line
+  t.deepEqual(events, [ '.js', '.css' ], 'listeners should be added for .js and .css events')
+})

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,3 @@
+const test = require('tape')
+
+test('server') // needs tests


### PR DESCRIPTION
@Fauntleroy I've made some improvements to the way the client js is set up. Let me know if this suits your needs and addresses your concerns from #6?

You can `require('hot-rld/_client')` directly if you want the source JS but the main use case should be to load `require('hot-rld/client')` which loads the JS string that is required to populate a `<script>` tag.